### PR TITLE
Use outputs.primitives instead of outputs.sprites

### DIFF
--- a/frame-timer.rb
+++ b/frame-timer.rb
@@ -80,7 +80,7 @@ class FrameTimer
       @frame_index = 0
     end
 
-    args.outputs.sprites << {
+    args.outputs.primitives << {
       x: @graph_x, y: @graph_y, w: @graph_width, h: @graph_height, path: :frame_timing
     }
   end


### PR DESCRIPTION
Based on render order, https://docs.dragonruby.org/#/api/outputs?id=collection-render-orders, if `sprites` is used, `primitives` will render on top of the graph.

By using `outputs.primitives`, this ensures that the graph is rendered on the top-most layer.